### PR TITLE
Pubmatic: Support passing of skadn object to PubMatic SSP

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -47,9 +47,10 @@ type pubmaticBidExtVideo struct {
 
 type ExtImpBidderPubmatic struct {
 	adapters.ExtImpBidder
-	Data json.RawMessage `json:"data,omitempty"`
-	AE   int             `json:"ae,omitempty"`
-	GpId string          `json:"gpid,omitempty"`
+	Data        json.RawMessage `json:"data,omitempty"`
+	AE          int             `json:"ae,omitempty"`
+	GpId        string          `json:"gpid,omitempty"`
+	SKAdnetwork json.RawMessage `json:"skadn,omitempty"`
 }
 
 type ExtAdServer struct {
@@ -80,6 +81,7 @@ const (
 	AdServerKey        = "adserver"
 	PBAdslotKey        = "pbadslot"
 	gpIdKey            = "gpid"
+	skAdnetworkKey     = "skadn"
 )
 
 func (a *PubmaticAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
@@ -334,6 +336,10 @@ func parseImpressionObject(imp *openrtb2.Imp, extractWrapperExtFromImp, extractP
 
 	if bidderExt.GpId != "" {
 		extMap[gpIdKey] = bidderExt.GpId
+	}
+
+	if bidderExt.SKAdnetwork != nil {
+		extMap[skAdnetworkKey] = bidderExt.SKAdnetwork
 	}
 
 	imp.Ext = nil

--- a/adapters/pubmatic/pubmatictest/supplemental/app.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/app.json
@@ -27,6 +27,10 @@
                         "version": 1,
                         "profile": 5123
                     }
+                },
+                "skadn": {
+                  "skadnetids": ["k674qkevps.skadnetwork"],
+                  "version": "2.0"
                 }
             }
         }],
@@ -64,7 +68,11 @@
                 "bidfloor": 0.12,
                 "ext": {
                     "pmZoneId": "Zone1,Zone2",
-                    "preference": "sports,movies"
+                    "preference": "sports,movies",
+                    "skadn": {
+                      "skadnetids": ["k674qkevps.skadnetwork"],
+                      "version": "2.0"
+                    }
                 }
               }
             ], 

--- a/adapters/pubmatic/pubmatictest/supplemental/impExt.json
+++ b/adapters/pubmatic/pubmatictest/supplemental/impExt.json
@@ -33,7 +33,18 @@
                             "cricket"
                         ]
                     },
-                    "gpid":"/1111/home"
+                    "gpid":"/1111/home",
+                    "skadn": {
+                        "versions": [
+                            "2.0",
+                            "2.1"
+                        ],
+                        "sourceapp": "11111",
+                        "skadnetids": [
+                            "424m5254lk.skadnetwork",
+                            "4fzdc2evr5.skadnetwork"
+                        ]
+                    }
                 }
             }
         ],
@@ -70,7 +81,18 @@
                             "ext": {
                                 "dfp_ad_unit_code": "/1111/home",
                                 "key_val": "k1=v1|k2=v2|sport=rugby,cricket",
-                                "gpid":"/1111/home"
+                                "gpid":"/1111/home",
+                                "skadn": {
+                                    "versions": [
+                                        "2.0",
+                                        "2.1"
+                                    ],
+                                    "sourceapp": "11111",
+                                    "skadnetids": [
+                                        "424m5254lk.skadnetwork",
+                                        "4fzdc2evr5.skadnetwork"
+                                    ]
+                                }
                             }
                         }
                     ],


### PR DESCRIPTION
**Feature:** Pass `skadn` object in `imp.ext` to PubMatic SSP

**Summary:**
This PR updates the PubMatic bidder adapter in Prebid Server to forward the `imp.ext.skadn` object (if present in the incoming OpenRTB request) to the PubMatic SSP endpoint.

**Changes in this PR:**

- Updates PubMatic bidder code to support `imp.ext.skadn`
- Ensures the `skadn` object is passed as-is without alteration
- Maintains backward compatibility if skadn is absent

Adds unit tests:
- Validates skadn is passed when present
- Skadn object is excluded when missing